### PR TITLE
:sparkles: feat(jobs): add social share buttons to job detail page UI

### DIFF
--- a/src/app/jobs/post/JobPostClient.tsx
+++ b/src/app/jobs/post/JobPostClient.tsx
@@ -9,7 +9,6 @@ import {
   ArrowLeft,
   Tag,
   Briefcase,
-  Share2,
   FileText,
   Mail,
   CalendarClock,
@@ -23,6 +22,58 @@ import type { JobPost } from "@/lib/firebase/types";
 import { useTranslations } from "next-intl";
 import { useLanguage } from "@/hooks/useLanguage";
 import { khitHaungg } from "@/fonts/fonts";
+import {
+  FaFacebookF,
+  FaXTwitter,
+  FaLinkedinIn,
+  FaTelegram,
+} from "react-icons/fa6";
+import type { IconType } from "react-icons";
+
+type SharePlatform = "facebook" | "twitter" | "linkedin" | "telegram";
+
+function ShareActions({
+  shareLabel,
+  onShare,
+}: {
+  shareLabel: string;
+  onShare: (platform: SharePlatform) => void;
+}) {
+  const platforms: Array<{
+    platform: SharePlatform;
+    label: string;
+    icon: IconType;
+  }> = [
+    { platform: "facebook", label: "Facebook", icon: FaFacebookF },
+    { platform: "twitter", label: "Twitter/X", icon: FaXTwitter },
+    { platform: "linkedin", label: "LinkedIn", icon: FaLinkedinIn },
+    { platform: "telegram", label: "Telegram", icon: FaTelegram },
+  ];
+
+  const buttonClassName =
+    "w-8 h-8 sm:w-auto sm:h-auto sm:px-2.5 sm:py-1.5 rounded-lg text-[10px] font-mono uppercase tracking-wider text-zinc-500 hover:text-zinc-200 bg-white/[0.03] border border-white/[0.06] hover:border-white/[0.1] transition-all duration-200 flex items-center justify-center";
+
+  return (
+    <div className="flex items-center gap-2 sm:gap-2.5">
+      <span className="hidden sm:inline text-[10px] font-mono uppercase tracking-wider text-zinc-600 mr-1.5">{shareLabel}</span>
+      {platforms.map(({ platform, label, icon: Icon }) => (
+        <button
+          key={platform}
+          type="button"
+          onClick={() => onShare(platform)}
+          className={buttonClassName}
+          aria-label={`Share this job on ${label}`}
+          title={`Share this job on ${label}`}
+        >
+          <span aria-hidden="true" className="sm:hidden text-[12px]">
+            <Icon />
+          </span>
+          <span className="hidden sm:inline">{label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
 
 function JobPostInner() {
   const searchParams = useSearchParams();
@@ -136,12 +187,23 @@ function JobPostInner() {
         year: "numeric",
       });
 
-  const handleShare = async () => {
-    if (navigator.share) {
-      await navigator.share({ title: post.position, url: window.location.href });
-    } else {
-      await navigator.clipboard.writeText(window.location.href);
-    }
+  const getShareLinks = () => {
+    const url = window.location.href;
+    const text = `Check out this job: ${post.position}`;
+    const encodedUrl = encodeURIComponent(url);
+    const encodedText = encodeURIComponent(text);
+
+    return {
+      facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+      twitter: `https://twitter.com/intent/tweet?text=${encodedText}&url=${encodedUrl}`,
+      linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+      telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`,
+    };
+  };
+
+  const openShare = (platform: SharePlatform) => {
+    const links = getShareLinks();
+    window.open(links[platform], "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -172,14 +234,7 @@ function JobPostInner() {
             <span className="font-mono text-xs uppercase tracking-wider">{t("allJobs")}</span>
           </MseLink>
 
-          <button
-            type="button"
-            onClick={handleShare}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-mono uppercase tracking-wider text-zinc-500 hover:text-zinc-200 bg-white/[0.03] border border-white/[0.06] hover:border-white/[0.1] transition-all duration-200"
-          >
-            <Share2 className="w-3 h-3" />
-            {t("share")}
-          </button>
+          <ShareActions shareLabel={t("share")} onShare={openShare} />
         </motion.div>
 
         {/* Header card */}
@@ -424,14 +479,7 @@ function JobPostInner() {
               <span className="font-mono text-xs uppercase tracking-wider">{t("allJobs")}</span>
             </MseLink>
 
-            <button
-              type="button"
-              onClick={handleShare}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-mono uppercase tracking-wider text-zinc-500 hover:text-zinc-200 bg-white/[0.03] border border-white/[0.06] hover:border-white/[0.1] transition-all duration-200"
-            >
-              <Share2 className="w-3 h-3" />
-              {t("share")}
-            </button>
+            <ShareActions shareLabel={t("share")} onShare={openShare} />
           </div>
         </motion.div>
       </article>


### PR DESCRIPTION
### **🎯 Summary**

Replaced the generic single “Share” action on the job detail page with dedicated platform share buttons for Facebook, Twitter/X, LinkedIn, and Telegram.
Each button opens a new tab with pre-filled share URL/text, and share UI with a reusable local component.

---
### **📋 What Changed**

src/app/jobs/post/JobPostClient.tsx

---

### **Features**

✅ Dedicated social share actions (Facebook, Twitter/X, LinkedIn, Telegram)
✅ Pre-filled share message + current job URL
✅ Opens secure new tabs (noopener,noreferrer)
✅ Reusable local [ShareActions] component
✅ Accessibility improvements ([aria-label] + [title] per button)
✅ Mobile-friendly behavior (icon-only on small screens, full labels on larger screens)

---

### **🎮 How It Works**

- User opens a job detail page: [/jobs/post?slug=...]
- Clicks one of the platform share buttons
- App builds platform-specific share URL with encoded text + page URL
- Share page opens in a new tab

---

### **✅ Testing Checklist**

Open [/jobs/post?slug=<valid-slug>]

- [ ] Click each share button (Facebook/X/LinkedIn/Telegram)
- [ ] Verify each opens correct platform share page in a new tab
- [ ] Verify shared text includes job title and URL
- [ ] Verify mobile viewport shows icon-only buttons
- [ ] Verify desktop/tablet shows full text labels
- [ ] Verify [aria-label] and [title] are present on share buttons

---

### **Work of validation**


https://github.com/user-attachments/assets/e75dcb9b-ef4f-474c-9f94-7e2fd7972b1e

---

Future Improvements Suggestion

- Add 'Copy Link' Action Button for the people who want to share in other channels(eg. viber, reddit and so on...)
- Can remove the one 'To All Jobs' and 'Share Buttons' section. Currently available on on both top and bottom of the job detail